### PR TITLE
fix: Use cli args with the highest priority

### DIFF
--- a/bin/vuex-guardian.js
+++ b/bin/vuex-guardian.js
@@ -36,7 +36,21 @@ try {
   config = require('../dist/config').config
 } finally {
   require('../dist').run({
-    build: program.build,
-    ...config
+    ...config,
+    ...(typeof program.storeDir === 'string'
+      ? {
+          storeDir: program.storeDir
+        }
+      : {}),
+    ...(typeof program.distDir === 'string'
+      ? {
+          distDir: program.distDir
+        }
+      : {}),
+    ...(program.build !== undefined
+      ? {
+          build: program.build
+        }
+      : {})
   })
 }


### PR DESCRIPTION
solves these issues.

1. `config.build` is [defaultly false](https://github.com/takefumi-yoshii/vuex-guardian/blob/48df37a48ca49eb7c5ffe222f722b2c88efdf4ca/src/config.ts#L52), and cli argument `--build` is also ignored.
2. Cli arguments `--storeDir` and `--distDir` seem to be ignored.